### PR TITLE
Attempt to insert nil object from objects

### DIFF
--- a/ios/RNS3/RNS3TransferUtility.m
+++ b/ios/RNS3/RNS3TransferUtility.m
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(setupWithCognito: (NSDictionary *)options) {
         @"totalBytes":@(totalBytes)
       },
       @"type":type,
-      @"error":errorObj
+      @"error":errorObj ? errorObj : [NSNull null]
     }];
 }
 


### PR DESCRIPTION
``` 
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]'

	0   CoreFoundation                      0x000000010d93ce65 __exceptionPreprocess + 165
	1   libobjc.A.dylib                     0x00000001101bedeb objc_exception_throw + 48
	2   CoreFoundation                      0x000000010d83f8ce -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 318
	3   CoreFoundation                      0x000000010d851c3b +[NSDictionary dictionaryWithObjects:forKeys:count:] + 59
	4   App                              0x000000010cf7e5f3 -[RNS3TransferUtility sendEvent:type:state:bytes:totalBytes:error:] + 1235
	5   App                                 0x000000010cf805fb __48-[RNS3TransferUtility upload:resolver:rejecter:]_block_invoke_2 + 107
```