### PR TITLE
Configure how often upload progress event emitted, as well as UI revamp

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -11,7 +11,7 @@ import React, {
 import { transferUtility } from "react-native-s3";
 import fs from "react-native-fs";
 
-const bucketName = "database-versame"; // name of bucket
+const bucketName = ""; // name of bucket
 const uploadFileKey = "ReactNativeTest/test.mp4"; // path to file in s3, excluding bucket
 const contentType = "image/jpeg"; // type of file
 const uploadFilePath = fs.DocumentDirectoryPath + "/test.mp4"; // file to be uploaded

--- a/src/TransferUtility.js
+++ b/src/TransferUtility.js
@@ -81,16 +81,17 @@ async function setTaskExtra(task, values, isNew) {
 }
 
 export default class TransferUtility {
-	async setupWithNative() {
+	async setupWithNative(subscribeProgress = true) {
 		const result = await RNS3TransferUtility.setupWithNative();
 		if (result) {
 			await getTaskExtras();
-			RNS3TransferUtility.initializeRNS3();
+			RNS3TransferUtility.initializeRNS3(subscribeProgress);
 		}
 		return result;
 	}
 
-	async setupWithBasic(options = {}) {
+	async setupWithBasic(options = {}, subscribeProgress = true) {
+		console.log(subscribeProgress);
 		if (!options.access_key || !options.secret_key) {
 			return false;
 		}
@@ -100,19 +101,19 @@ export default class TransferUtility {
 		const result = await RNS3TransferUtility.setupWithBasic({ ...defaultOptions, ...options});
 		if (result) {
 			await getTaskExtras();
-			RNS3TransferUtility.initializeRNS3();
+			RNS3TransferUtility.initializeRNS3(subscribeProgress);
 		}
 		return result;
 	}
 
-	async setupWithCognito(options = {}) {
+	async setupWithCognito(options = {}, subscribeProgress = true) {
 		if (!options.identity_pool_id) {
 			return false;
 		}
 		const result = await RNS3TransferUtility.setupWithBasic({ ...defaultCognitoOptions, ...options });
 		if (result) {
 			await getTaskExtras();
-			RNS3TransferUtility.initializeRNS3();
+			RNS3TransferUtility.initializeRNS3(subscribeProgress);
 		}
 		return result;
 	}


### PR DESCRIPTION
The justification for the UI revamp is as follows:

- Quite frankly I feel like only the transfers that occur in the current session use of the application should be logged - and not the complete history of the transferUtility. 

- I also logged in a more modular fashion so that users can look back on the progress, states, and file directories even after the upload/download succeeded or failed. Previously, once the upload failed or succeeded, the UI made it impossible to see the log of what occurred in the process, for example an error. 

- I additionally increased error logging visibility and the logging of both the s3 path of where the upload goes as well as the local file path of where a download goes.
