### PR TITLE
fix subscribe/unsubscribe..

### DIFF
--- a/src/TransferUtility.js
+++ b/src/TransferUtility.js
@@ -210,9 +210,9 @@ export default class TransferUtility {
 		if (!listeners[id]) {
 			listeners[id] = [];
 		}
-		const listeners = listeners[id];
-		if (listeners.indexOf(eventHandler) < 0) {
-			listeners.push(eventHandler);
+		const listenersForTask = listeners[id];
+		if (listenersForTask.indexOf(eventHandler) < 0) {
+			listenersForTask.push(eventHandler);
 		}
 	}
 
@@ -222,10 +222,10 @@ export default class TransferUtility {
 			delete listeners[id];
 			return;
 		}
-		const listeners = listeners[id];
-		const index = listeners.indexOf(eventHandler);
+		const listenersForTask = listeners[id];
+		const index = listenersForTask.indexOf(eventHandler);
 		if (index > 0) {
-			listeners.splice(index, 1);
+			listenersForTask.splice(index, 1);
 		}
 	}
 }


### PR DESCRIPTION
```js
const listeners = {};

subscribe () {
  // listeners === undefined

  if (!listeners[id]) { // cannot read property `id` of undefined..
    listeners[id] = [];
  }

  const listeners = listeners[id];
}
```

javascript *hoists* variables so even if the `listeners` variable is set outside of your function.. because you redefine it later in your function:
```js
const listeners = listeners[id];
```

its value is *undefined* between the beginning of the function and the line until that variable is set/reset.

anyways.. please test your code before pushing.. or at least use a linter that can catch these bugs such as eslint..