### PR TITLE
[iOS] Add `remember_last_instance` option for setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
 env:
   - CXX=g++-4.8

--- a/API.md
+++ b/API.md
@@ -18,6 +18,7 @@ Return: Promise - will resolve arguments:
   * `access_key` String - the AWS access key ID
   * `secret_key` String - the AWS secret access key
   * `session_token` String - (optional)
+  * `remember_last_instance` Boolean - keep the last transferUtility instance when JS reload (default: true) __(iOS)__
 
 Return: Promise - will resolve arguments:
 * Boolean - `true` or `false` depending on the setup successful.
@@ -29,6 +30,7 @@ Return: Promise - will resolve arguments:
   * `identity_pool_id` String - the Amazon Cogntio identity pool
   * `cognito_region` String - a Cognito Region (default: eu-west-1)
   * `caching` Boolean - use `CognitoCachingCredentialsProvider` instead of `CognitoCredentialsProvider` __(Android)__
+  * `remember_last_instance` Boolean - keep the last transferUtility instance when JS reload (default: true) __(iOS)__
 
 See AWS CognitoCredentialsProvider ([iOS](http://docs.aws.amazon.com/AWSiOSSDK/latest/Classes/AWSCognitoCredentialsProvider.html)/[Android](http://docs.aws.amazon.com/AWSAndroidSDK/latest/javadoc/com/amazonaws/auth/CognitoCredentialsProvider.html)) for more information.
 

--- a/src/TransferUtility.js
+++ b/src/TransferUtility.js
@@ -6,6 +6,7 @@ const { RNS3TransferUtility } = NativeModules;
 
 const transferTypes = ["upload", "download"];
 const defaultOptions = {
+	remember_last_instance: true,
 	region: "eu-west-1"
 };
 const defaultCognitoOptions = {


### PR DESCRIPTION
Remove last instance when setup again will fix #9, but we need keep last instance, otherwise JS reload will break background tasks, so provide `remember_last_instance` option may be better.

If you need to setup again with different config, just set `remember_last_instance` to false, and note that it will remove all tasks in progress.