### PR TITLE
Support camelcase string option name

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "extends": "mybigday"
   },
   "dependencies": {
-    "react-native-simple-store": "^1.0.1"
+    "react-native-simple-store": "^1.0.1",
+    "snake-case": "^2.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.17.0",

--- a/src/TransferUtility.js
+++ b/src/TransferUtility.js
@@ -1,6 +1,6 @@
 import { NativeModules, NativeAppEventEmitter, DeviceEventEmitter, Platform } from "react-native";
 import store from "react-native-simple-store";
-import { normalizeFilePath } from "./utils";
+import { normalizeFilePath, snakeCaseKeys } from "./utils";
 
 const { RNS3TransferUtility } = NativeModules;
 
@@ -98,13 +98,14 @@ export default class TransferUtility {
 	}
 
 	async setupWithBasic(options = {}) {
-		if (!options.access_key || !options.secret_key) {
+		const opts = snakeCaseKeys(options);
+		if (!opts.access_key || !opts.secret_key) {
 			return false;
 		}
 		if (Platform.OS === "android") {
-			options.session_token = options.session_token || null;
+			opts.session_token = opts.session_token || null;
 		}
-		const result = await RNS3TransferUtility.setupWithBasic({ ...defaultOptions, ...options});
+		const result = await RNS3TransferUtility.setupWithBasic({ ...defaultOptions, ...opts});
 		if (result) {
 			await getTaskExtras();
 			RNS3TransferUtility.initializeRNS3();
@@ -113,10 +114,11 @@ export default class TransferUtility {
 	}
 
 	async setupWithCognito(options = {}) {
-		if (!options.identity_pool_id) {
+		const opts = snakeCaseKeys(options);
+		if (!opts.identity_pool_id) {
 			return false;
 		}
-		const result = await RNS3TransferUtility.setupWithCognito({ ...defaultCognitoOptions, ...options });
+		const result = await RNS3TransferUtility.setupWithCognito({ ...defaultCognitoOptions, ...opts });
 		if (result) {
 			await getTaskExtras();
 			RNS3TransferUtility.initializeRNS3();
@@ -129,18 +131,19 @@ export default class TransferUtility {
 	}
 
 	async upload(options = {}, others = {}) {
-		options.meta = options.meta || {};
-		const { contentType } = options.meta;
+		const opts = snakeCaseKeys(options);
+		opts.meta = opts.meta || {};
+		const { contentType } = opts.meta;
 		if (contentType) {
-			options.meta["Content-Type"] = contentType;
+			opts.meta["Content-Type"] = contentType;
 		}
 		const task = await RNS3TransferUtility.upload({
-			...options,
-			file: normalizeFilePath(options.file)
+			...opts,
+			file: normalizeFilePath(opts.file)
 		});
 		const extra = {
-			bucket: options.bucket,
-			key: options.key,
+			bucket: opts.bucket,
+			key: opts.key,
 			others
 		};
 		if (Platform.OS === "ios") {
@@ -151,13 +154,14 @@ export default class TransferUtility {
 	}
 
 	async download(options = {}, others = {}) {
+		const opts = snakeCaseKeys(options);
 		const task = await RNS3TransferUtility.download({
 			...options,
-			file: normalizeFilePath(options.file)
+			file: normalizeFilePath(opts.file)
 		});
 		const extra = {
-			bucket: options.bucket,
-			key: options.key,
+			bucket: opts.bucket,
+			key: opts.key,
 			others
 		};
 		if (Platform.OS === "ios") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,13 @@
+import snakeCase from "snake-case"; 
+
 export const normalizeFilePath = path =>
-  path.startsWith("file://") ? path.slice(7) :
-  path;
+	path.startsWith("file://") ? path.slice(7) :
+	path;
+
+export const snakeCaseKeys = obj => {
+	const result = {};
+	Object.keys(obj).forEach(key => {
+		result[snakeCase(key)] = obj[key];
+	});
+	return result;
+};

--- a/test/TransferUtility.spec.js
+++ b/test/TransferUtility.spec.js
@@ -8,9 +8,9 @@ let downloadTaskStoreForNative = [];
 // Set RNS3TransferUtility mock
 NativeModules.RNS3TransferUtility = {
 	initializeRNS3: () => {},
-	setupWithNative: () => true,
-	setupWithBasic: () => {},
-	setupWithCognito: () => {},
+	setupWithNative: r => r,
+	setupWithBasic: r => r,
+	setupWithCognito: r => r,
 	enableProgressSent: () => {},
 	upload: () => {
 		const task = {
@@ -47,7 +47,15 @@ const delay = time => new Promise(resolve => setTimeout(resolve, time));
 describe("TransferUtility", () => {
 
 	before(async () => {
-		await transferUtility.setupWithNative();
+		expect(await transferUtility.setupWithBasic({
+			accessKey: "test",
+			secretKey: "test"
+		})).toEqual({
+			remember_last_instance: true,
+			region: "eu-west-1",
+			access_key: "test",
+			secret_key: "test"
+		});
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
Just make camelcase string option name can be use, we still keeping snake case option for native code (just  conversion in JS) for backward compatibility.