### PR TITLE
Metadata android

### DIFF
--- a/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
+++ b/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
@@ -245,11 +245,7 @@ public class RNS3TransferUtility extends ReactContextBaseJavaModule {
         String propKey = iter.nextKey();
         String value = meta.getString(propKey);
 
-        if (propKey.startsWith("x-amz-meta-")) {
-          metaData.addUserMetadata(propKey, value);
-        } else {
-          metaData.setHeader(propKey, value);
-        }
+        metaData.setHeader(propKey, value);
       }
       task = transferUtility.upload(bucket, key, file, metaData);
     } else {

--- a/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
+++ b/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
@@ -244,7 +244,12 @@ public class RNS3TransferUtility extends ReactContextBaseJavaModule {
       while (iter.hasNextKey()) {
         String propKey = iter.nextKey();
         String value = meta.getString(propKey);
-        metaData.addUserMetadata(propKey, value);
+
+        if (propKey.startsWith("x-amz-meta-")) {
+          metaData.addUserMetadata(propKey, value);
+        } else {
+          metaData.setHeader(propKey, value);
+        }
       }
       task = transferUtility.upload(bucket, key, file, metaData);
     } else {


### PR DESCRIPTION
On iOS adding an HTTP header (i.e. `Content-Encoding`) results in `Content-Encoding` being stored on S3. On Android this is added as an `x-amz-meta-content-encoding` header. 

This PR uses `setHeader` instead of `addUserMetadata` on Android to make the behavior the same for iOS and Android. This might break behavior for users that rely on the `x-amz-meta` behavior.