### PR TITLE
Upgrade aws sdk 2.19.1

### DIFF
--- a/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
+++ b/android/src/main/java/com/mybigday/rns3/RNS3TransferUtility.java
@@ -232,26 +232,32 @@ public class RNS3TransferUtility extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void upload(ReadableMap options, Promise promise) {
-    String bucket = options.getString("bucket");
-    String key = options.getString("key");
-    File file = new File(options.getString("file"));
-    ReadableMap meta = options.getMap("meta");
-    ObjectMetadata metaData = new ObjectMetadata();
+    try {
+      String bucket = options.getString("bucket");
+      String key = options.getString("key");
+      File file = new File(options.getString("file"));
+      ReadableMap meta = options.getMap("meta");
+      ObjectMetadata metaData = new ObjectMetadata();
 
-    TransferObserver task;
-    if (meta != null) {
-      ReadableMapKeySetIterator iter = meta.keySetIterator();
-      while (iter.hasNextKey()) {
-        String propKey = iter.nextKey();
-        String value = meta.getString(propKey);
-        metaData.addUserMetadata(propKey, value);
+      TransferObserver task;
+      if (meta != null) {
+        ReadableMapKeySetIterator iter = meta.keySetIterator();
+        while (iter.hasNextKey()) {
+          String propKey = iter.nextKey();
+          String value = meta.getString(propKey);
+          metaData.addUserMetadata(propKey, value);
+        }
+        task = transferUtility.upload(bucket, key, file, metaData);
+      } else {
+        task = transferUtility.upload(bucket, key, file);
       }
-      task = transferUtility.upload(bucket, key, file, metaData);
-    } else {
-      task = transferUtility.upload(bucket, key, file);
+      subscribe(task);
+      promise.resolve(convertTransferObserver(task));
+    } catch (IllegalArgumentException e){
+        promise.reject(e);
+    } catch(Exception e){
+      promise.reject(e);
     }
-    subscribe(task);
-    promise.resolve(convertTransferObserver(task));
   }
 
   @ReactMethod

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint src test example/*.js",
     "test": "npm run lint && mocha",
-    "prepare": "npm test && ./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
+    "prepare": "./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "eslint src test example/*.js",
     "test": "npm run lint && mocha",
-    "prepare": "./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
+    "download": "./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace",
+    "prepublish": "npm test && ./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint src test example/*.js",
     "test": "npm run lint && mocha",
-    "prepublish": "npm test && ./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
+    "prepare": "npm test && ./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-native-s3",
-  "version": "0.0.29",
+  "version": "0.0.29-1",
   "description": "A React Native wrapper for AWS S3 SDK",
   "main": "./src/index.js",
   "files": ["android/", "ios/", "src/"],
   "scripts": {
     "lint": "eslint src test example/*.js",
     "test": "npm run lint && mocha",
-    "download": "./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace",
+    "download": "SKIP_DOWNLOAD_SDK_IF_EXISTS=1 ./scripts/download-ios.sh 2.19.1 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace",
     "prepublish": "npm test && ./scripts/download-ios.sh 2.5.2 && rm -rf ./ios/RNS3.xcodeproj/xcuserdata ./ios/RNS3.xcodeproj/project.xcworkspace"
   },
   "repository": {

--- a/scripts/download-ios.sh
+++ b/scripts/download-ios.sh
@@ -19,8 +19,8 @@ if [ -d ./AWSCognito.framework ]; then rm -rf ./AWSCognito.framework; fi;
 
 curl -sS http://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-$VERSION.zip > temp.zip
 unzip -o temp.zip -d temp
-mv temp/frameworks/AWSCore.framework ./AWSCore.framework
-mv temp/frameworks/AWSS3.framework ./AWSS3.framework
-mv temp/frameworks/AWSCognito.framework ./AWSCognito.framework
+mv temp/aws-ios-sdk-$VERSION/frameworks/AWSCore.framework ./AWSCore.framework
+mv temp/aws-ios-sdk-$VERSION/frameworks/AWSS3.framework ./AWSS3.framework
+mv temp/aws-ios-sdk-$VERSION/frameworks/AWSCognito.framework ./AWSCognito.framework
 rm -r temp
 rm temp.zip


### PR DESCRIPTION
* AWS iOS SDKを2.19.1にアップデート
* なお、これ以降の最新版へのアップデートは以下の理由により困難
  * `framework`形式から`xcframework`形式にデータ形式が変更になった
  * AWSCognito SDKが廃止になった 